### PR TITLE
fix: add routing frontmatter to commands

### DIFF
--- a/commands/debug-tx.md
+++ b/commands/debug-tx.md
@@ -1,3 +1,23 @@
+---
+name: "debug-tx"
+version: "1.0.0"
+description: |
+  Decode revert reasons, trace internal calls, and explain transaction
+  failures in plain language. Routes to tx-forensics skill.
+
+arguments:
+  - name: "tx_hash"
+    description: "Transaction hash to debug"
+    required: false
+
+agent: "tx-forensics"
+agent_path: "skills/tx-forensics"
+
+context_files:
+  - path: "CLAUDE.md"
+    required: true
+---
+
 # /debug-tx — Decode and Explain Failed Transactions
 
 Decode revert reasons, trace internal calls, and explain transaction failures in plain language.

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,3 +1,26 @@
+---
+name: "verify"
+version: "1.0.0"
+description: |
+  Read deployed contract state and compare against frontend constants.
+  The core Protocol workflow. Routes to contract-verify skill.
+
+arguments:
+  - name: "address"
+    description: "Contract address to verify"
+    required: false
+  - name: "chain"
+    description: "Chain ID (e.g. 80084 for Berachain bartio)"
+    required: false
+
+agent: "contract-verify"
+agent_path: "skills/contract-verify"
+
+context_files:
+  - path: "CLAUDE.md"
+    required: true
+---
+
 # /verify — Ground Frontend in On-Chain Reality
 
 Read deployed contract state and compare against frontend constants. The core Protocol workflow.


### PR DESCRIPTION
## Summary

Adds YAML frontmatter with `agent`/`agent_path`/`context_files` to both command files (`debug-tx.md`, `verify.md`). Skills already have triggers — this was the only missing convention.

Part of network-wide routing conventions audit. See [construct-base-review.md](https://github.com/0xHoneyJar/loa-constructs/blob/main/grimoires/bridgebuilder/construct-base-review.md).

## Related PRs
- `construct-base#4` — template fix
- `construct-k-hole#5` — full invocation fix

Generated with [Claude Code](https://claude.com/claude-code)