### PR TITLE
fix: load persona.yaml in command context_files

### DIFF
--- a/commands/debug-tx.md
+++ b/commands/debug-tx.md
@@ -16,6 +16,8 @@ agent_path: "skills/tx-forensics"
 context_files:
   - path: "CLAUDE.md"
     required: true
+  - path: "identity/persona.yaml"
+    required: true
 ---
 
 # /debug-tx — Decode and Explain Failed Transactions

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -19,6 +19,8 @@ agent_path: "skills/contract-verify"
 context_files:
   - path: "CLAUDE.md"
     required: true
+  - path: "identity/persona.yaml"
+    required: true
 ---
 
 # /verify — Ground Frontend in On-Chain Reality


### PR DESCRIPTION
## Summary

Both commands now load `identity/persona.yaml` in `context_files`.

Protocol's persona has "Trust-nothing, verify-everything" and "Assume the frontend lies until the chain confirms" — this cognitive frame needs to activate when running `/debug-tx` and `/verify`, not just exist as a dormant file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)