### PR TITLE
feat: add short_description for storefront tagline

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -8,6 +8,7 @@ name: Protocol
 slug: protocol
 version: 2.0.0
 description: "On-chain verification and QA for Web3 dApps — grounds frontend behavior in contract reality from click to receipt. Verifies the wallet boundary: chain switching, error handling, simulation gating, and receipt lifecycle. Never trust the frontend, verify the chain."
+short_description: "On-chain verification"
 author: 0xHoneyJar
 license: MIT
 type: skill-pack


### PR DESCRIPTION
Add `short_description` field to `construct.yaml` for constructs.network catalog display.

Tagline: **On-chain verification**

Part of 0xHoneyJar/loa-constructs#157

🤖 Generated with [Claude Code](https://claude.com/claude-code)