### PR TITLE
chore: add composition_paths and compose_with metadata

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -80,6 +80,12 @@ events:
     - event: forge.artisan.taste_inscribed
       delivery: at-least-once
 
+composition_paths:
+  writes:
+    - "grimoires/protocol/"
+compose_with:
+  - observer
+  - artisan
 pack_dependencies:
   - slug: observer
   - slug: artisan


### PR DESCRIPTION
## Summary
- Adds `composition_paths.writes: [grimoires/protocol/]` — protocol writes verification reports
- Adds `compose_with: [observer, artisan]` — formalizes the existing dependencies already expressed via `pack_dependencies` and event consumption

## Why
Part of the ecosystem-wide composition metadata fan-out. Protocol consumes observer gaps and artisan taste events, now formally declared for network routing.

## Test plan
- [ ] `yq eval '.' construct.yaml` parses without error
- [ ] Fields are additive only — no existing fields modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)