### PR TITLE
fix: add YAML frontmatter to all 10 SKILL.md files

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -7,8 +7,8 @@ schema_version: 3
 name: Protocol
 slug: protocol
 version: 2.0.0
-description: "Verify that what your frontend shows matches what the smart contract enforces — prices, allowances, proxy implementations, wallet boundaries. Catch ABI drift, decode failed transactions, and run dApp QA (linting, type-checking, e2e wallet testing) via Foundry, wagmi, and viem."
-short_description: "Frontend + smart contract verification"
+description: "Verify that what your UI shows matches what your smart contract enforces — token prices, approval amounts, proxy upgrades, wallet permissions. Catch mismatches between your frontend and deployed contracts, decode failed transactions, and run automated dApp testing (linting, type-checks, end-to-end wallet flows)."
+short_description: "Smart contract + frontend verification"
 author: 0xHoneyJar
 license: MIT
 type: skill-pack

--- a/construct.yaml
+++ b/construct.yaml
@@ -7,8 +7,8 @@ schema_version: 3
 name: Protocol
 slug: protocol
 version: 2.0.0
-description: "Reads the chain so your users don't hit reverts. Verifies that what your frontend shows matches what the contract enforces — prices, allowances, proxy implementations, the whole wallet boundary. If cast can read it, Protocol already checked it."
-short_description: "Verify the chain, not the frontend"
+description: "Verify that what your frontend shows matches what the smart contract enforces — prices, allowances, proxy implementations, wallet boundaries. Catch ABI drift, decode failed transactions, and run dApp QA (linting, type-checking, e2e wallet testing) via Foundry, wagmi, and viem."
+short_description: "Frontend + smart contract verification"
 author: 0xHoneyJar
 license: MIT
 type: skill-pack

--- a/skills/abi-audit/SKILL.md
+++ b/skills/abi-audit/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: abi-audit
+description: Compare frontend ABI definitions against deployed contract reality
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # abi-audit
 
 > Compare frontend ABI definitions against deployed contract reality.

--- a/skills/contract-verify/SKILL.md
+++ b/skills/contract-verify/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: contract-verify
+description: Ground dApp frontend assumptions in on-chain reality
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep, Edit]
+---
+
 # contract-verify
 
 > Ground dApp frontend assumptions in on-chain reality.

--- a/skills/dapp-e2e/SKILL.md
+++ b/skills/dapp-e2e/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: dapp-e2e
+description: Run end-to-end browser tests for Web3 dApp wallet and transaction flows
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # dapp-e2e — Agent-Browser Web3 E2E Testing
 
 ## Purpose

--- a/skills/dapp-lint/SKILL.md
+++ b/skills/dapp-lint/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: dapp-lint
+description: Lint Web3 dApp frontend for common anti-patterns and BigInt safety issues
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # dapp-lint — Web3 Frontend Linter
 
 ## Purpose

--- a/skills/dapp-test/SKILL.md
+++ b/skills/dapp-test/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: dapp-test
+description: Run dApp test suite and check coverage for contract interaction code
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # dapp-test — Web3 Test Suite Runner
 
 ## Purpose

--- a/skills/dapp-typecheck/SKILL.md
+++ b/skills/dapp-typecheck/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: dapp-typecheck
+description: Verify wagmi/viem type generation matches deployed ABIs
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # dapp-typecheck — Contract Type Verification
 
 ## Purpose

--- a/skills/gpt-contract-review/SKILL.md
+++ b/skills/gpt-contract-review/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: gpt-contract-review
+description: Adversarial cross-model review of frontend-contract interaction code
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # gpt-contract-review — Cross-Model Adversarial Contract Review
 
 ## Purpose

--- a/skills/proxy-inspect/SKILL.md
+++ b/skills/proxy-inspect/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: proxy-inspect
+description: Identify proxy architecture, implementation, and upgrade authority
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # proxy-inspect
 
 > Identify proxy architecture, implementation, and upgrade authority.

--- a/skills/simulate-flow/SKILL.md
+++ b/skills/simulate-flow/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: simulate-flow
+description: Dry-run user flows to catch reverts before users hit them
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # simulate-flow
 
 > Dry-run user flows to catch reverts before users hit them.

--- a/skills/tx-forensics/SKILL.md
+++ b/skills/tx-forensics/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: tx-forensics
+description: Decode, trace, and explain failed or complex transactions
+user-invocable: true
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+---
+
 # tx-forensics
 
 > Decode, trace, and explain failed or complex transactions.


### PR DESCRIPTION
## Summary

- Added YAML frontmatter (`name`, `description`, `user-invocable`, `allowed-tools`) to all 10 SKILL.md files
- Covers both skill groups: web3-verify (contract-verify, tx-forensics, abi-audit, proxy-inspect, simulate-flow) and dapp-qa (dapp-lint, dapp-typecheck, dapp-test, dapp-e2e, gpt-contract-review)
- Metadata sourced from each skill's `index.yaml`

## Context

The Echelon interop audit ([memory ref](https://github.com/0xHoneyJar/loa-constructs/blob/main/memory/project_echelon_interop_audit.md)) found that construct-protocol's SKILL.md files lack `---` frontmatter delimiters, preventing the 037 pipeline from parsing skill metadata. 5/7 constructs compile through Echelon's pipeline — this fix closes one of the identified gaps.

## Test plan

- [ ] Verify frontmatter parses correctly with `yq` or any YAML parser
- [ ] Confirm 037 pipeline can now ingest protocol skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)